### PR TITLE
New feature: Change Download Path on right click

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -231,10 +231,16 @@ async function changeDownloadPath(){
 	console.log("New download path set to: " + downloadPath);
 }
 
+async function changeDownloadPath_onRightClick(path){
+
+	downloadPath = path.fsPath.split(/(?:\.)([^\/]*)$/g)[0];
+	console.log("New download path set to: " + downloadPath);
+}
 
 	// Download the selected image to the current workplace
 	// TODO prompt the user asking him for a download folder, if no active workspace is active. 
 async function downloadImage(imageSource){
+	console.log(downloadPath);
 	if(downloadPath === undefined){
 		console.log("undefined dP " + downloadPath);
 		if(vscode.workspace.rootPath === undefined)
@@ -249,7 +255,10 @@ async function downloadImage(imageSource){
 	let downloadSettings= {
 		extract: false
 	};
+	console.log(imageSource);
+	console.log(downloadPath);
 	await download(imageSource, downloadPath, downloadSettings);
+	console.log("fin download");
 	vscode.window.showInformationMessage("Picture Downloaded!");
 
 	
@@ -403,7 +412,10 @@ function activate(context) {
 		rotatePicture(180, path);
 	})
 
-
+	let downloadPathModifier = vscode.commands.registerCommand('pictury.downloadPathModifier', function(path=vscode.Uri) {
+		changeDownloadPath_onRightClick(path);
+	})
+	
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(disposable2);
 	context.subscriptions.push(toPNG);
@@ -412,6 +424,7 @@ function activate(context) {
 	context.subscriptions.push(rotateRight180);
 	context.subscriptions.push(rotateLeft90);
 	context.subscriptions.push(rotateLeft180);
+	context.subscriptions.push(downloadPathModifier);
 }
 
 // this method is called when your extension is deactivated

--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
       {
         "command": "pictury.rotateLeft180",
         "title": "Rotate Left 180°"
-      }
+      },
+      {
+        "command": "pictury.downloadPathModifier",
+        "title": "Set To Download Folder"
+      } 
     ],
     "keybindings": [
       {
@@ -62,6 +66,17 @@
           "submenu": "pictury",
           "group": "navigation",
           "when": "resourceExtname == .jpg || resourceExtname == .png || resourceExtname == jpeg"
+        },
+        {
+          "submenu": "Pictury",
+          "group": "navigation",
+          "when": "explorerResourceIsFolder"
+        }
+      ],
+      "Pictury": [
+        {
+          "command": "pictury.downloadPathModifier",
+          "group": "navigation"
         }
       ],
       "pictury": [
@@ -100,6 +115,10 @@
     "submenus": [
       {
         "id": "pictury",
+        "label": "pictury"
+      },
+      {
+        "id": "Pictury",
         "label": "pictury"
       }
     ]


### PR DESCRIPTION
By right-clicking on any folder in your workspace, you can set that folder as the 'Download Folder'. The next pictures you're going to download using Pictury will get downloaded in that folder.